### PR TITLE
Transpose data back again before returning to R

### DIFF
--- a/src/mlpack_mst.cpp
+++ b/src/mlpack_mst.cpp
@@ -34,6 +34,10 @@ Rcpp::NumericMatrix mlpack_mst(arma::mat& data)
 	mstResults.row(0) = mstResults.row(0) + 1; //start index = 0 in C++
 	mstResults.row(1) = mstResults.row(1) + 1;
 	
+
+	// transpose the matrix back to how it was, for returning to R
+	data = data.t();
+
 	// returning a matrix instead of a list - v2
 	return Rcpp::wrap(mstResults); 
 }


### PR DESCRIPTION
Hi, thank you for creating this package, which is being used to analyse the UK's broadband infrastructure.

The input coordinates are jumbled by the time they are returned by `ComputeMST()`.  This is caused by the C++ code transposing the coordinates in-place, which can happen even though the object is passed by reference.  See https://stackoverflow.com/questions/24112893/within-c-functions-how-are-rcpp-objects-passed-to-other-functions-by-referen).

So when the data is transposed for ComputeMST, it must be transposed back again before returning to R, otherwise the x,y coordinates will be jumbled in the data frame returned to the user.

This pull request implements that change by transposing the data back.  Alternatively, a copy could be made of the data, but that would double the memory consumption.

Here is an example demonstrating the current behaviour.

``` r
library(emstreeR)

# Create four points
coords <- data.frame(x = c(1, 3, 2, 4), y = c(5, 6, 7, 8), label = letters[1:4])
coords
#>   x y label
#> 1 1 5     a
#> 2 3 6     b
#> 3 2 7     c
#> 4 4 8     d

# Plot the points
plot(x ~ y, data = coords, pch = NA)
text(x ~ y, data = coords, labels = label)
```

![](https://i.imgur.com/U58dfkv.png)

``` r
# Compute the Minimum Spanning Tree
mst <- ComputeMST(coords[, 1:2])
#> 3 edges found so far.
#> 12 cumulative base cases.
#> 0 cumulative node combinations scored.
#> Total spanning tree length: 5.88635

# Plot the tree, noting that the points are now in different places.
plot.MST(mst)
```

![](https://i.imgur.com/3cj2FCY.png)

``` r
# Inside emstreeR::ComputeMST(), this data_aux object is created.
data_aux <- data_check(coords[, 1:2])
data_aux
#>      [,1] [,2]
#> [1,]    1    5
#> [2,]    3    6
#> [3,]    2    7
#> [4,]    4    8

# Then it is passed to emstreeR::mlpack_mst(), which hands it off to C++
from_to_matrix <- mlpack_mst(data_aux)
#> 3 edges found so far.
#> 12 cumulative base cases.
#> 0 cumulative node combinations scored.
#> Total spanning tree length: 5.88635

# And now data_aux has been jumbled
data_aux
#>      [,1] [,2]
#> [1,]    1    2
#> [2,]    5    7
#> [3,]    3    4
#> [4,]    6    8
```

<sup>Created on 2020-11-26 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>
